### PR TITLE
Add Copy of Patent Language to README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-NOTE: The language below should already be included in file `0-preface.adoc`. It is replicated here for convenience.
+NOTE: The language below should already be included in the `0-preface.adoc` source file. It is replicated here for convenience.
 =====
 
 *LICENSE AGREEMENT*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Intellectual Property Rights
+The content of this document is copyrighted by the Open Geospatial Consortium (OGC) and may be [licensed](https://github.com/opengeospatial/er_template/blob/master/LICENSE) for designated purposes.
+
+=============
+NOTE: The language below should already be included in the `1-summary.adoc` source file. It is replicated here for convenience.
+=============
+
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
+
+Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation.
+
 # Overview
 This is a template proposed for Testbed-14 Engineering Reports.  The objective is for editors to check this out (Clone a version) and begin editing it with a tool such as e.g. Atom editor and Asciidoctor conversion tool.
 
@@ -20,12 +31,12 @@ It is very important that the names of the file er.adoc will not be changed, as 
   * annex-history.adoc
   * annex-bibliography.adoc
 
-=============
-I have found the following User Guide very helpful:  http://www.methods.co.nz/asciidoc/userguide.html
-
 # How to compile your raw files
 Command for PDF output:
 asciidoctor-pdf -a pdf-stylesdir=resources -a pdf-style=ogc -a pdf-fontsdir=resources/fonts cfp.adoc
 
 Command for HTML output:
 asciidoctor -a stylesheet=rocket-panda.css -a stylesdir=./resources/stylesheets cfp.adoc
+
+=============
+This [User Guide](http://www.methods.co.nz/asciidoc/userguide.html) might provide additional help to authors.


### PR DESCRIPTION
Add language clarifying the OGC intellectual property rights, including a link to the LICENSE and a restatement of the patent call from 1-summary.adoc.